### PR TITLE
[Feature] Activate & Deactivate command

### DIFF
--- a/src/Commands/ActivateEntityCommand.php
+++ b/src/Commands/ActivateEntityCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SaasReady\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use SaasReady\Constants\CurrencyCode;
+use SaasReady\Constants\LanguageCode;
+use SaasReady\Models\Currency;
+use RuntimeException;
+use BackedEnum;
+use SaasReady\Models\Language;
+
+class ActivateEntityCommand extends Command
+{
+    protected $signature = 'saas-ready:activate-entity {entity} {code}';
+    protected $description = 'Activate an entity';
+
+    public function handle(): int
+    {
+        $entity = $this->getEntity();
+
+        if ($entity === null) {
+            $this->error('Entity with the ' . $this->argument('code') . ' identifier does not exists');
+
+            return 1;
+        }
+
+        $entity->update([
+            'activated_at' => now(),
+        ]);
+
+        $this->info('Activated the entity ' . ($entity->code instanceof BackedEnum ? $entity->code->value : $entity->code));
+
+        return 0;
+    }
+
+    public function getEntity(): ?Model
+    {
+        $code = $this->argument('code');
+
+        return match ($this->argument('entity')) {
+            'currency' => Currency::findByCode(CurrencyCode::tryFrom($code)),
+            'language' => Language::findByCode(LanguageCode::tryFrom($code)),
+            default => throw new RuntimeException('Unsupported entity'),
+        };
+    }
+}

--- a/src/Commands/DeactivateEntityCommand.php
+++ b/src/Commands/DeactivateEntityCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SaasReady\Commands;
+
+use BackedEnum;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+use SaasReady\Constants\CurrencyCode;
+use SaasReady\Constants\LanguageCode;
+use SaasReady\Models\Currency;
+use SaasReady\Models\Language;
+
+class DeactivateEntityCommand extends Command
+{
+    protected $signature = 'saas-ready:deactivate-entity {entity} {code}';
+    protected $description = 'Deactivate an entity';
+
+    public function handle(): int
+    {
+        $entity = $this->getEntity();
+
+        if ($entity === null) {
+            $this->error('Entity with the ' . $this->argument('code') . ' identifier does not exists');
+
+            return 1;
+        }
+
+        $entity->update([
+            'activated_at' => null,
+        ]);
+
+        $this->info('Deactivated the entity ' . ($entity->code instanceof BackedEnum ? $entity->code->value : $entity->code));
+
+        return 0;
+    }
+
+    public function getEntity(): ?Model
+    {
+        $code = $this->argument('code');
+
+        return match ($this->argument('entity')) {
+            'currency' => Currency::findByCode(CurrencyCode::tryFrom($code)),
+            'language' => Language::findByCode(LanguageCode::tryFrom($code)),
+            default => throw new RuntimeException('Unsupported entity'),
+        };
+    }
+}

--- a/src/SaasServiceProvider.php
+++ b/src/SaasServiceProvider.php
@@ -7,6 +7,8 @@ use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use SaasReady\Commands\ActivateEntityCommand;
+use SaasReady\Commands\DeactivateEntityCommand;
 use SaasReady\Contracts\EventSourcingContract;
 use SaasReady\Contracts\TranslationRepositoryContract;
 use SaasReady\Listeners\EventSourcingListener;
@@ -31,6 +33,7 @@ class SaasServiceProvider extends ServiceProvider
 
         $this->loadMigrationsFrom(__DIR__ . '/Database/Migrations');
         $this->loadRoutesFrom(__DIR__ . '/Routes/saas-ready-routes.php');
+        $this->loadArtisanCommands();
 
         Event::listen(EventSourcingContract::class, function (EventSourcingContract $event) {
             if (!config('saas-ready.event-sourcing.should-queue')) {
@@ -66,5 +69,17 @@ class SaasServiceProvider extends ServiceProvider
 
             return $this->app->make(DatabaseTranslationRepository::class);
         });
+    }
+
+    private function loadArtisanCommands(): void
+    {
+        if (!$this->app->runningInConsole()) {
+            return;
+        }
+
+        $this->commands([
+            ActivateEntityCommand::class,
+            DeactivateEntityCommand::class,
+        ]);
     }
 }

--- a/tests/Feature/Commands/ActivateEntityCommandTest.php
+++ b/tests/Feature/Commands/ActivateEntityCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SaasReady\Tests\Feature\Commands;
+
+use SaasReady\Constants\CurrencyCode;
+use SaasReady\Constants\LanguageCode;
+use SaasReady\Models\Currency;
+use SaasReady\Models\Language;
+use SaasReady\Tests\TestCase;
+use RuntimeException;
+use TypeError;
+
+class ActivateEntityCommandTest extends TestCase
+{
+    public function testActivateNotSupportEntityThrowsAnError()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->artisan('saas-ready:activate-entity abcxyz code')
+            ->execute();
+    }
+
+    public function testActivateNonExistsEntityThrowsAnError()
+    {
+        // CurrencyCode enum got our back
+        $this->expectException(TypeError::class);
+
+        $this->artisan('saas-ready:activate-entity currency AAAA')
+            ->execute();
+    }
+
+    public function testActivateNonExistsEntityReturnsAnError()
+    {
+        $this->artisan('saas-ready:activate-entity currency USD')
+            ->assertFailed()
+            ->expectsOutputToContain('identifier does not exists')
+            ->execute();
+    }
+
+    public function testActivateCurrencyOk()
+    {
+        $currency = Currency::factory()->create([
+            'code' => CurrencyCode::UNITED_STATES_DOLLAR,
+            'activated_at' => null,
+        ]);
+
+        $this->artisan('saas-ready:activate-entity currency USD')
+            ->assertOk()
+            ->execute();
+
+        $currency->refresh();
+
+        $this->assertNotNull($currency->activated_at);
+    }
+
+    public function testActivateLanguageOk()
+    {
+        $language = Language::factory()->create([
+            'code' => LanguageCode::ENGLISH,
+            'activated_at' => null,
+        ]);
+
+        $this->artisan('saas-ready:activate-entity language en')
+            ->assertOk()
+            ->execute();
+
+        $language->refresh();
+
+        $this->assertNotNull($language->activated_at);
+    }
+}

--- a/tests/Feature/Commands/DeactivateEntityCommandTest.php
+++ b/tests/Feature/Commands/DeactivateEntityCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SaasReady\Tests\Feature\Commands;
+
+use SaasReady\Constants\CurrencyCode;
+use SaasReady\Constants\LanguageCode;
+use SaasReady\Models\Currency;
+use SaasReady\Models\Language;
+use SaasReady\Tests\TestCase;
+use RuntimeException;
+use TypeError;
+
+class DeactivateEntityCommandTest extends TestCase
+{
+    public function testDeactivateNotSupportEntityThrowsAnError()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->artisan('saas-ready:deactivate-entity abcxyz code')
+            ->execute();
+    }
+
+    public function testDeactivateNonExistsEntityThrowsAnError()
+    {
+        // CurrencyCode enum got our back
+        $this->expectException(TypeError::class);
+
+        $this->artisan('saas-ready:deactivate-entity currency AAAA')
+            ->execute();
+    }
+
+    public function testDeactivateNonExistsEntityReturnsAnError()
+    {
+        $this->artisan('saas-ready:deactivate-entity currency USD')
+            ->assertFailed()
+            ->expectsOutputToContain('identifier does not exists')
+            ->execute();
+    }
+
+    public function testDeactivateCurrencyOk()
+    {
+        $currency = Currency::factory()->create([
+            'code' => CurrencyCode::UNITED_STATES_DOLLAR,
+            'activated_at' => now(),
+        ]);
+
+        $this->artisan('saas-ready:deactivate-entity currency USD')
+            ->assertOk()
+            ->execute();
+
+        $currency->refresh();
+
+        $this->assertNull($currency->activated_at);
+    }
+
+    public function testDeactivateLanguageOk()
+    {
+        $language = Language::factory()->create([
+            'code' => LanguageCode::ENGLISH,
+            'activated_at' => now(),
+        ]);
+
+        $this->artisan('saas-ready:deactivate-entity language en')
+            ->assertOk()
+            ->execute();
+
+        $language->refresh();
+
+        $this->assertNull($language->activated_at);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace SaasReady\Tests;
 use Illuminate\Foundation\Testing\WithFaker;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use SaasReady\Models\Currency;
 use SaasReady\SaasServiceProvider;
 
 abstract class TestCase extends BaseTestCase
@@ -15,6 +16,8 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        Currency::$currencyCaches = [];
     }
 
     protected function getPackageProviders($app): array


### PR DESCRIPTION
## Feature

Would come in handy if you want to quickly enabling/disabling entities.

Supported entities:
- currency
- language

### Usage

```php
php artisan saas-ready:activate-entity {entity} {code}
php artisan saas-ready:activate-entity currency USD

php artisan saas-ready:deactivate-entity {entity} {code}
php artisan saas-ready:deactivate-entity language en-SG
```