### PR TITLE
Custom Authorization Check

### DIFF
--- a/src/Auth/ReadyAuthorization.php
+++ b/src/Auth/ReadyAuthorization.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SaasReady\Auth;
+
+use Closure;
+
+final class ReadyAuthorization
+{
+    /**
+     * @var array<string, Closure>
+     */
+    private static array $customAuthorizations = [
+        'events.index' => null,
+        'events.show' => null,
+
+        'countries.index' => null,
+        'countries.show' => null,
+        'countries.store' => null,
+        'countries.update' => null,
+        'countries.destroy' => null,
+
+        'currencies.index' => null,
+        'currencies.show' => null,
+        'currencies.store' => null,
+        'currencies.update' => null,
+        'currencies.destroy' => null,
+
+        'languages.index' => null,
+        'languages.show' => null,
+        'languages.store' => null,
+        'languages.update' => null,
+        'languages.destroy' => null,
+
+        'release-notes.index' => null,
+        'release-notes.show' => null,
+        'release-notes.store' => null,
+        'release-notes.update' => null,
+        'release-notes.destroy' => null,
+
+        'dynamic-settings.index' => null,
+        'dynamic-settings.show' => null,
+        'dynamic-settings.store' => null,
+        'dynamic-settings.update' => null,
+        'dynamic-settings.destroy' => null,
+    ];
+
+    /**
+     * Set Custom Authorization check
+     *
+     * @param string $endpointName
+     * @param callable $customAuthorization
+     *  - 1st param will be the FormRequest
+     *  - You must be a boolean
+     *
+     * @return void
+     */
+    public static function setCustomAuthorization(
+        string $endpointName,
+        callable $customAuthorization
+    ): void {
+        ReadyAuthorization::$customAuthorizations[$endpointName] = $customAuthorization;
+    }
+
+    public static function getAuthorization(string $endpointName): Closure
+    {
+        return (ReadyAuthorization::$customAuthorizations[$endpointName] ?? fn () => true)
+            ?: fn () => true;
+    }
+}

--- a/src/Auth/ReadyAuthorization.php
+++ b/src/Auth/ReadyAuthorization.php
@@ -42,6 +42,12 @@ final class ReadyAuthorization
         'dynamic-settings.store' => null,
         'dynamic-settings.update' => null,
         'dynamic-settings.destroy' => null,
+
+        'translations.index' => null,
+        'translations.show' => null,
+        'translations.store' => null,
+        'translations.update' => null,
+        'translations.destroy' => null,
     ];
 
     /**

--- a/src/Http/Controllers/DynamicSettingsController.php
+++ b/src/Http/Controllers/DynamicSettingsController.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Facades\Event;
 use SaasReady\Events\DynamicSetting\DynamicSettingCreated;
 use SaasReady\Events\DynamicSetting\DynamicSettingDeleted;
 use SaasReady\Events\DynamicSetting\DynamicSettingUpdated;
+use SaasReady\Http\Requests\DynamicSetting\DynamicSettingDestroyRequest;
 use SaasReady\Http\Requests\DynamicSetting\DynamicSettingIndexRequest;
+use SaasReady\Http\Requests\DynamicSetting\DynamicSettingShowRequest;
 use SaasReady\Http\Requests\DynamicSetting\DynamicSettingStoreRequest;
 use SaasReady\Http\Requests\DynamicSetting\DynamicSettingUpdateRequest;
 use SaasReady\Http\Responses\DynamicSettingResource;
@@ -27,8 +29,10 @@ class DynamicSettingsController extends Controller
         return DynamicSettingResource::collection($dynamicSettings)->response();
     }
 
-    public function show(DynamicSetting $dynamicSetting): JsonResponse
-    {
+    public function show(
+        DynamicSettingShowRequest $request,
+        DynamicSetting $dynamicSetting
+    ): JsonResponse {
         return (new DynamicSettingResource($dynamicSetting))->response();
     }
 
@@ -68,8 +72,10 @@ class DynamicSettingsController extends Controller
         ]);
     }
 
-    public function destroy(DynamicSetting $dynamicSetting): JsonResponse
-    {
+    public function destroy(
+        DynamicSettingDestroyRequest $request,
+        DynamicSetting $dynamicSetting
+    ): JsonResponse {
         if ($dynamicSetting->model_id === null && $dynamicSetting->model_type === null) {
             return new JsonResponse([
                 'error' => 'Global dynamic setting can not be deleted',

--- a/src/Http/Requests/BaseFormRequest.php
+++ b/src/Http/Requests/BaseFormRequest.php
@@ -2,25 +2,23 @@
 
 namespace SaasReady\Http\Requests;
 
-use Closure;
 use Illuminate\Foundation\Http\FormRequest;
+use SaasReady\Auth\ReadyAuthorization;
 
-class BaseFormRequest extends FormRequest
+abstract class BaseFormRequest extends FormRequest
 {
-    protected static ?Closure $customAuthorize = null;
+    public function authorize(): bool
+    {
+        return call_user_func(
+            ReadyAuthorization::getAuthorization($this->getEndpointName()),
+            $this
+        );
+    }
+
+    abstract protected function getEndpointName(): string;
 
     public function wantsPagination(): bool
     {
         return $this->input('type') !== 'all';
-    }
-
-    public static function setCustomAuthorize(callable $customAuthorize): void
-    {
-        static::$customAuthorize = $customAuthorize;
-    }
-
-    public function authorize(): bool
-    {
-        return call_user_func(static::$customAuthorize ?: fn () => true);
     }
 }

--- a/src/Http/Requests/BaseFormRequest.php
+++ b/src/Http/Requests/BaseFormRequest.php
@@ -2,12 +2,25 @@
 
 namespace SaasReady\Http\Requests;
 
+use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 
 class BaseFormRequest extends FormRequest
 {
+    protected static ?Closure $customAuthorize = null;
+
     public function wantsPagination(): bool
     {
         return $this->input('type') !== 'all';
+    }
+
+    public static function setCustomAuthorize(callable $customAuthorize): void
+    {
+        static::$customAuthorize = $customAuthorize;
+    }
+
+    public function authorize(): bool
+    {
+        return call_user_func(static::$customAuthorize ?: fn () => true);
     }
 }

--- a/src/Http/Requests/Country/CountryDestroyRequest.php
+++ b/src/Http/Requests/Country/CountryDestroyRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CountryDestroyRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'countries.destroy';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Country/CountryDestroyRequest.php
+++ b/src/Http/Requests/Country/CountryDestroyRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CountryDestroyRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Country/CountryIndexRequest.php
+++ b/src/Http/Requests/Country/CountryIndexRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CountryIndexRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Country/CountryIndexRequest.php
+++ b/src/Http/Requests/Country/CountryIndexRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CountryIndexRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'countries.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Country/CountryShowRequest.php
+++ b/src/Http/Requests/Country/CountryShowRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CountryShowRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'countries.show';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Country/CountryShowRequest.php
+++ b/src/Http/Requests/Country/CountryShowRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CountryShowRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Country/CountryStoreRequest.php
+++ b/src/Http/Requests/Country/CountryStoreRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Country;
 
 class CountryStoreRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Country/CountryStoreRequest.php
+++ b/src/Http/Requests/Country/CountryStoreRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Country;
 
 class CountryStoreRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'countries.store';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Country/CountryUpdateRequest.php
+++ b/src/Http/Requests/Country/CountryUpdateRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Country;
 
 class CountryUpdateRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'countries.update';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Country/CountryUpdateRequest.php
+++ b/src/Http/Requests/Country/CountryUpdateRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Country;
 
 class CountryUpdateRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Currency/CurrencyDestroyRequest.php
+++ b/src/Http/Requests/Currency/CurrencyDestroyRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CurrencyDestroyRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'currencies.destroy';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Currency/CurrencyDestroyRequest.php
+++ b/src/Http/Requests/Currency/CurrencyDestroyRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CurrencyDestroyRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Currency/CurrencyIndexRequest.php
+++ b/src/Http/Requests/Currency/CurrencyIndexRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CurrencyIndexRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'currencies.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Currency/CurrencyIndexRequest.php
+++ b/src/Http/Requests/Currency/CurrencyIndexRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CurrencyIndexRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Currency/CurrencyShowRequest.php
+++ b/src/Http/Requests/Currency/CurrencyShowRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CurrencyShowRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'currencies.show';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Currency/CurrencyShowRequest.php
+++ b/src/Http/Requests/Currency/CurrencyShowRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class CurrencyShowRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Currency/CurrencyStoreRequest.php
+++ b/src/Http/Requests/Currency/CurrencyStoreRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Currency;
 
 class CurrencyStoreRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Currency/CurrencyStoreRequest.php
+++ b/src/Http/Requests/Currency/CurrencyStoreRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Currency;
 
 class CurrencyStoreRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'currencies.store';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Currency/CurrencyUpdateRequest.php
+++ b/src/Http/Requests/Currency/CurrencyUpdateRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Currency;
 
 class CurrencyUpdateRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Currency/CurrencyUpdateRequest.php
+++ b/src/Http/Requests/Currency/CurrencyUpdateRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Currency;
 
 class CurrencyUpdateRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'currencies.update';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/DynamicSetting/DynamicSettingDestroyRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingDestroyRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SaasReady\Http\Requests\DynamicSetting;
+
+use Illuminate\Foundation\Http\FormRequest;
+use SaasReady\Rules\ClassExistsRule;
+
+class DynamicSettingDestroyRequest extends FormRequest
+{
+    protected function getEndpointName(): string
+    {
+        return 'dynamic-settings.destroy';
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/src/Http/Requests/DynamicSetting/DynamicSettingDestroyRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingDestroyRequest.php
@@ -3,9 +3,10 @@
 namespace SaasReady\Http\Requests\DynamicSetting;
 
 use Illuminate\Foundation\Http\FormRequest;
+use SaasReady\Http\Requests\BaseFormRequest;
 use SaasReady\Rules\ClassExistsRule;
 
-class DynamicSettingDestroyRequest extends FormRequest
+class DynamicSettingDestroyRequest extends BaseFormRequest
 {
     protected function getEndpointName(): string
     {

--- a/src/Http/Requests/DynamicSetting/DynamicSettingIndexRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingIndexRequest.php
@@ -3,9 +3,10 @@
 namespace SaasReady\Http\Requests\DynamicSetting;
 
 use Illuminate\Foundation\Http\FormRequest;
+use SaasReady\Http\Requests\BaseFormRequest;
 use SaasReady\Rules\ClassExistsRule;
 
-class DynamicSettingIndexRequest extends FormRequest
+class DynamicSettingIndexRequest extends BaseFormRequest
 {
     protected function getEndpointName(): string
     {

--- a/src/Http/Requests/DynamicSetting/DynamicSettingIndexRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingIndexRequest.php
@@ -7,11 +7,6 @@ use SaasReady\Rules\ClassExistsRule;
 
 class DynamicSettingIndexRequest extends FormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/DynamicSetting/DynamicSettingIndexRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingIndexRequest.php
@@ -7,6 +7,11 @@ use SaasReady\Rules\ClassExistsRule;
 
 class DynamicSettingIndexRequest extends FormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'dynamic-settings.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/DynamicSetting/DynamicSettingShowRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingShowRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SaasReady\Http\Requests\DynamicSetting;
+
+use Illuminate\Foundation\Http\FormRequest;
+use SaasReady\Rules\ClassExistsRule;
+
+class DynamicSettingShowRequest extends FormRequest
+{
+    protected function getEndpointName(): string
+    {
+        return 'dynamic-settings.show';
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/src/Http/Requests/DynamicSetting/DynamicSettingShowRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingShowRequest.php
@@ -3,9 +3,10 @@
 namespace SaasReady\Http\Requests\DynamicSetting;
 
 use Illuminate\Foundation\Http\FormRequest;
+use SaasReady\Http\Requests\BaseFormRequest;
 use SaasReady\Rules\ClassExistsRule;
 
-class DynamicSettingShowRequest extends FormRequest
+class DynamicSettingShowRequest extends BaseFormRequest
 {
     protected function getEndpointName(): string
     {

--- a/src/Http/Requests/DynamicSetting/DynamicSettingStoreRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingStoreRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Rules\ClassExistsRule;
 
 class DynamicSettingStoreRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'dynamic-settings.store';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/DynamicSetting/DynamicSettingStoreRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingStoreRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Rules\ClassExistsRule;
 
 class DynamicSettingStoreRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/DynamicSetting/DynamicSettingUpdateRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingUpdateRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Rules\ClassExistsRule;
 
 class DynamicSettingUpdateRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'dynamic-settings.update';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/DynamicSetting/DynamicSettingUpdateRequest.php
+++ b/src/Http/Requests/DynamicSetting/DynamicSettingUpdateRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Rules\ClassExistsRule;
 
 class DynamicSettingUpdateRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Event/EventIndexRequest.php
+++ b/src/Http/Requests/Event/EventIndexRequest.php
@@ -10,11 +10,6 @@ class EventIndexRequest extends BaseFormRequest
 {
     private ?Model $source = null;
 
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Event/EventIndexRequest.php
+++ b/src/Http/Requests/Event/EventIndexRequest.php
@@ -10,6 +10,11 @@ class EventIndexRequest extends BaseFormRequest
 {
     private ?Model $source = null;
 
+    protected function getEndpointName(): string
+    {
+        return 'events.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Event/EventShowRequest.php
+++ b/src/Http/Requests/Event/EventShowRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class EventShowRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Event/EventShowRequest.php
+++ b/src/Http/Requests/Event/EventShowRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class EventShowRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'events.show';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Language/LanguageDestroyRequest.php
+++ b/src/Http/Requests/Language/LanguageDestroyRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class LanguageDestroyRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'languages.destroy';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Language/LanguageDestroyRequest.php
+++ b/src/Http/Requests/Language/LanguageDestroyRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class LanguageDestroyRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Language/LanguageIndexRequest.php
+++ b/src/Http/Requests/Language/LanguageIndexRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class LanguageIndexRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Language/LanguageIndexRequest.php
+++ b/src/Http/Requests/Language/LanguageIndexRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class LanguageIndexRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'languages.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Language/LanguageShowRequest.php
+++ b/src/Http/Requests/Language/LanguageShowRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class LanguageShowRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Language/LanguageShowRequest.php
+++ b/src/Http/Requests/Language/LanguageShowRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class LanguageShowRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'languages.show';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Language/LanguageStoreRequest.php
+++ b/src/Http/Requests/Language/LanguageStoreRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Language;
 
 class LanguageStoreRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'languages.store';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Language/LanguageStoreRequest.php
+++ b/src/Http/Requests/Language/LanguageStoreRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Language;
 
 class LanguageStoreRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Language/LanguageUpdateRequest.php
+++ b/src/Http/Requests/Language/LanguageUpdateRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Language;
 
 class LanguageUpdateRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Language/LanguageUpdateRequest.php
+++ b/src/Http/Requests/Language/LanguageUpdateRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Language;
 
 class LanguageUpdateRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'languages.update';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteDestroyRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteDestroyRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class ReleaseNoteDestroyRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteDestroyRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteDestroyRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class ReleaseNoteDestroyRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'release-notes.destroy';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteIndexRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteIndexRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class ReleaseNoteIndexRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'release-notes.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteIndexRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteIndexRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class ReleaseNoteIndexRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteShowRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteShowRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class ReleaseNoteShowRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'release-notes.show';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteShowRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteShowRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class ReleaseNoteShowRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteStoreRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteStoreRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Country;
 
 class ReleaseNoteStoreRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteStoreRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteStoreRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Country;
 
 class ReleaseNoteStoreRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'release-notes.store';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteUpdateRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteUpdateRequest.php
@@ -8,11 +8,6 @@ use SaasReady\Models\Country;
 
 class ReleaseNoteUpdateRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/ReleaseNote/ReleaseNoteUpdateRequest.php
+++ b/src/Http/Requests/ReleaseNote/ReleaseNoteUpdateRequest.php
@@ -8,6 +8,11 @@ use SaasReady\Models\Country;
 
 class ReleaseNoteUpdateRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'release-notes.update';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Translation/TranslationDestroyRequest.php
+++ b/src/Http/Requests/Translation/TranslationDestroyRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class TranslationDestroyRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'translations.destroy';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Translation/TranslationDestroyRequest.php
+++ b/src/Http/Requests/Translation/TranslationDestroyRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class TranslationDestroyRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Translation/TranslationIndexRequest.php
+++ b/src/Http/Requests/Translation/TranslationIndexRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class TranslationIndexRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'translations.index';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Translation/TranslationIndexRequest.php
+++ b/src/Http/Requests/Translation/TranslationIndexRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class TranslationIndexRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Translation/TranslationShowRequest.php
+++ b/src/Http/Requests/Translation/TranslationShowRequest.php
@@ -6,6 +6,11 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class TranslationShowRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'translations.show';
+    }
+
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Translation/TranslationShowRequest.php
+++ b/src/Http/Requests/Translation/TranslationShowRequest.php
@@ -6,11 +6,6 @@ use SaasReady\Http\Requests\BaseFormRequest;
 
 class TranslationShowRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [];

--- a/src/Http/Requests/Translation/TranslationStoreRequest.php
+++ b/src/Http/Requests/Translation/TranslationStoreRequest.php
@@ -9,6 +9,11 @@ use SaasReady\Rules\TranslationValuesRule;
 
 class TranslationStoreRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'translations.store';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Translation/TranslationStoreRequest.php
+++ b/src/Http/Requests/Translation/TranslationStoreRequest.php
@@ -9,11 +9,6 @@ use SaasReady\Rules\TranslationValuesRule;
 
 class TranslationStoreRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Translation/TranslationUpdateRequest.php
+++ b/src/Http/Requests/Translation/TranslationUpdateRequest.php
@@ -9,6 +9,11 @@ use SaasReady\Rules\TranslationValuesRule;
 
 class TranslationUpdateRequest extends BaseFormRequest
 {
+    protected function getEndpointName(): string
+    {
+        return 'translations.update';
+    }
+
     public function rules(): array
     {
         return [

--- a/src/Http/Requests/Translation/TranslationUpdateRequest.php
+++ b/src/Http/Requests/Translation/TranslationUpdateRequest.php
@@ -9,11 +9,6 @@ use SaasReady\Rules\TranslationValuesRule;
 
 class TranslationUpdateRequest extends BaseFormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/tests/Unit/Requests/FormRequestTest.php
+++ b/tests/Unit/Requests/FormRequestTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SaasReady\Tests\Unit\Requests;
+
+use SaasReady\Auth\ReadyAuthorization;
+use SaasReady\Http\Requests\Event\EventIndexRequest;
+use SaasReady\Http\Requests\Event\EventShowRequest;
+use SaasReady\Tests\TestCase;
+
+class FormRequestTest extends TestCase
+{
+    public function testSetCustomAuthorization()
+    {
+        ReadyAuthorization::setCustomAuthorization(
+            'events.index',
+            fn () => false
+        );
+        ReadyAuthorization::setCustomAuthorization(
+            'events.show',
+            fn () => true
+        );
+
+        $requestA = new EventIndexRequest();
+        $requestB = new EventShowRequest();
+
+        $this->assertFalse($requestA->authorize());
+        $this->assertTrue($requestB->authorize());
+    }
+}


### PR DESCRIPTION
In case you don't want to add a bunch of `if` `else` in your middleware, then this is a new way 

Usage:

```php
use SaasReady\Auth\ReadyAuthorization;

// AppServiceProvider.php  - boot
ReadyAuthorization::setCustomAuthorization('endpoint-key', function ($request) {
    return $request->user()->can('...');
});
```

All endpoint keys are listed in `ReadyAuthorization::$customAuthorizations`

===
Additionally, added 2 missing requests of `DynamicSetting` (show, destroy)